### PR TITLE
Add Molecule testing framework and GitHub Actions CI

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,14 @@
+---
+profile: production
+
+exclude_paths:
+  - .github/
+  - molecule/
+
+skip_list:
+  - role-name  # Role name doesn't match pattern
+  - no-changed-when  # Commands with 'creates' are idempotent
+  - latest[git]  # We intentionally clone latest for source compilation
+
+warn_list:
+  - command-instead-of-shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible-lint yamllint
+
+      - name: Run yamllint
+        run: yamllint .
+
+      - name: Run ansible-lint
+        run: ansible-lint
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Molecule tests
+        run: molecule test
+        env:
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+      - "yes"
+      - "no"
+
+ignore:
+  - .github/

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,4 +6,4 @@
     ffmpeg_root_dir: /root
 
   roles:
-    - role: ansible-ffmpeg
+    - role: "{{ playbook_dir }}/../.."

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    ffmpeg_root_dir: /root
+
+  roles:
+    - role: ansible-ffmpeg

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,63 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu2204
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    pre_build_image: true
+    privileged: true
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+
+  - name: ubuntu2404
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    pre_build_image: true
+    privileged: true
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+
+  - name: debian12
+    image: geerlingguy/docker-debian12-ansible:latest
+    pre_build_image: true
+    privileged: true
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      ubuntu2204:
+        ansible_user: root
+      ubuntu2404:
+        ansible_user: root
+      debian12:
+        ansible_user: root
+
+verifier:
+  name: ansible
+
+scenario:
+  name: default
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -38,6 +38,9 @@ provisioner:
   playbooks:
     converge: converge.yml
     verify: verify.yml
+  config_options:
+    defaults:
+      roles_path: ../../
   inventory:
     host_vars:
       ubuntu2204:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,52 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Check ffmpeg binary exists
+      ansible.builtin.stat:
+        path: /root/bin/ffmpeg
+      register: ffmpeg_binary
+
+    - name: Assert ffmpeg exists
+      ansible.builtin.assert:
+        that:
+          - ffmpeg_binary.stat.exists
+        fail_msg: "FFmpeg binary not found at /root/bin/ffmpeg"
+        success_msg: "FFmpeg binary found"
+
+    - name: Check ffprobe binary exists
+      ansible.builtin.stat:
+        path: /root/bin/ffprobe
+      register: ffprobe_binary
+
+    - name: Assert ffprobe exists
+      ansible.builtin.assert:
+        that:
+          - ffprobe_binary.stat.exists
+        fail_msg: "FFprobe binary not found at /root/bin/ffprobe"
+        success_msg: "FFprobe binary found"
+
+    - name: Get ffmpeg version
+      ansible.builtin.command:
+        cmd: /root/bin/ffmpeg -version
+      register: ffmpeg_version
+      changed_when: false
+
+    - name: Display ffmpeg version
+      ansible.builtin.debug:
+        msg: "{{ ffmpeg_version.stdout_lines[0] }}"
+
+    - name: Test ffmpeg can encode
+      ansible.builtin.shell: |
+        /root/bin/ffmpeg -f lavfi -i testsrc=duration=1:size=320x240:rate=1 -f null -
+      register: ffmpeg_encode_test
+      changed_when: false
+
+    - name: Assert encoding works
+      ansible.builtin.assert:
+        that:
+          - ffmpeg_encode_test.rc == 0
+        fail_msg: "FFmpeg encoding test failed"
+        success_msg: "FFmpeg encoding test passed"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ansible>=2.10
+molecule>=6.0
+molecule-plugins[docker]>=23.0
+ansible-lint>=6.0
+yamllint>=1.26

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -136,7 +136,9 @@
 
     - name: Compile libvpx
       ansible.builtin.shell: |
-        ./configure --prefix={{ ffmpeg_build_dir }} --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=nasm
+        ./configure --prefix={{ ffmpeg_build_dir }} \
+          --disable-examples --disable-unit-tests \
+          --enable-vp9-highbitdepth --as=nasm
         make -j$(nproc)
         make install
       args:


### PR DESCRIPTION
- Add Molecule configuration with Docker driver
- Test on Ubuntu 22.04, Ubuntu 24.04, Debian 12
- Add verify.yml with functional tests (ffmpeg encoding)
- Add GitHub Actions workflow (lint + molecule)
- Add ansible-lint and yamllint configurations